### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -11,7 +11,7 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install npx (for prettier)
         run: sudo apt install nodejs

--- a/.github/workflows/doc-test.yml
+++ b/.github/workflows/doc-test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Run entrypoint checks"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: "Install ripgrep"
         run: sudo apt-get install -y ripgrep
       - name: Check the repo for wrong entrypoint mentions
@@ -29,7 +29,7 @@ jobs:
     name: "Extract and run tests"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Update crates we care about

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Check if links are valid"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0